### PR TITLE
Updated code to use io.Closer instead of custom Closable.  Added .git…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Go template
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+.idea
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+

--- a/death_unix_test.go
+++ b/death_unix_test.go
@@ -43,14 +43,16 @@ func TestDeath(t *testing.T) {
 type neverClose struct {
 }
 
-func (n *neverClose) Close() {
+func (n *neverClose) Close() error {
 	time.Sleep(2 * time.Minute)
+	return nil
 }
 
 type CloseMe struct {
 	Closed int
 }
 
-func (c *CloseMe) Close() {
+func (c *CloseMe) Close() error {
 	c.Closed++
+	return nil
 }


### PR DESCRIPTION
…ignore.  Adjusted tests for revision.  Should be backward compatible for the most part.

I think most code will follow the Closer interface and so can be added to the WaitForDeath without having to be wrapped.  Also, the signature accounts for an error return, which this code doesn't yet handle or report yet.