### PR TITLE
Add call to manually initiate death

### DIFF
--- a/death.go
+++ b/death.go
@@ -120,8 +120,8 @@ func (d *Death) closeObjects(closer closer, done chan<- closer) {
 	done <- closer
 }
 
-//InitiateDeath manually initiates the death process.
-func (d *Death) InitiateDeath() {
+//FallOnSword manually initiates the death process.
+func (d *Death) FallOnSword() {
 	d.callChannel <- struct{}{}
 }
 

--- a/death_unix_test.go
+++ b/death_unix_test.go
@@ -30,6 +30,14 @@ func TestDeath(t *testing.T) {
 		So(closeMe.Closed, ShouldEqual, 1)
 	})
 
+	Convey("Validate death happens with a manual call", t, func() {
+		death := NewDeath(syscall.SIGHUP)
+		closeMe := &CloseMe{}
+		death.InitiateDeath()
+		death.WaitForDeath(closeMe)
+		So(closeMe.Closed, ShouldEqual, 1)
+	})
+
 	Convey("Validate death gives up after timeout", t, func() {
 		death := NewDeath(syscall.SIGHUP)
 		death.setTimeout(10 * time.Millisecond)

--- a/death_unix_test.go
+++ b/death_unix_test.go
@@ -33,7 +33,7 @@ func TestDeath(t *testing.T) {
 	Convey("Validate death happens with a manual call", t, func() {
 		death := NewDeath(syscall.SIGHUP)
 		closeMe := &CloseMe{}
-		death.InitiateDeath()
+		death.FallOnSword()
 		death.WaitForDeath(closeMe)
 		So(closeMe.Closed, ShouldEqual, 1)
 	})


### PR DESCRIPTION
Instead of sending an OS-specific signal to a process, would you be amenable to also allowing a process to manually initiate it's own death?  I intentionally didn't use the obvious metaphor for such a process in naming the method, etc. because it seems too gloomy.