### PR TITLE
Bubble up error when timeout is triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Use gopkg.in to import death based on your logger.
 
 Version | Go Get URL | source | doc | Notes |
 --------|------------|--------|-----|-------|
-2.x     | [gopkg.in/vrecan/death.v2](https://gopkg.in/vrecan/death.v2)| [source]() | [doc]() | This supports loggers who _do not_ return an error from their `Error` and `Warn` functions like [logrus](https://github.com/sirupsen/logrus)
+3.x     | [gopkg.in/vrecan/death.v3](https://gopkg.in/vrecan/death.v3)| [source](https://github.com/vrecan/death/tree/v3.0) | [doc](https://godoc.org/gopkg.in/vrecan/death.v3) | This removes the need for an independent logger. By default death will not log but will return an error if all the closers do not properly close. If you want to provide a logger just satisfy the deathlog.Logger interface.
+2.x     | [gopkg.in/vrecan/death.v2](https://gopkg.in/vrecan/death.v2)| [source](https://github.com/vrecan/death/tree/v2.0) | [doc](https://godoc.org/gopkg.in/vrecan/death.v2) | This supports loggers who _do not_ return an error from their `Error` and `Warn` functions like [logrus](https://github.com/sirupsen/logrus)
 1.x     | [gopkg.in/vrecan/death.v1](https://gopkg.in/vrecan/death.v1)| [souce](https://github.com/vrecan/death/tree/v1.0) | [doc](https://godoc.org/gopkg.in/vrecan/death.v1) | This supports loggers who _do_ return an error from their `Error` and `Warn` functions like [seelog](https://github.com/cihub/seelog)
 
 
@@ -42,6 +43,7 @@ func main() {
 package main
 
 import (
+	"log"
 	DEATH "github.com/vrecan/death"
 	SYS "syscall"
 	"io"
@@ -54,7 +56,11 @@ func main() {
 	objects = append(objects, &NewType{}) // this will work as long as the type implements a Close method
 
 	//when you want to block for shutdown signals
-	death.WaitForDeath(objects...) // this will finish when a signal of your type is sent to your application
+	err := death.WaitForDeath(objects...) // this will finish when a signal of your type is sent to your application
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
 }
 
 type NewType struct {

--- a/death.go
+++ b/death.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/grindlemire/death/deathlog"
 )
 
 // Death manages the death of your application.
@@ -21,15 +21,7 @@ type Death struct {
 	sigChannel  chan os.Signal
 	callChannel chan struct{}
 	timeout     time.Duration
-	log         Logger
-}
-
-// Logger interface to log.
-type Logger interface {
-	Error(v ...interface{})
-	Debug(v ...interface{})
-	Info(v ...interface{})
-	Warn(v ...interface{})
+	log         deathlog.Logger
 }
 
 // closer is a wrapper to the struct we are going to close with metadata
@@ -47,7 +39,7 @@ func NewDeath(signals ...os.Signal) (death *Death) {
 		sigChannel:  make(chan os.Signal, 1),
 		callChannel: make(chan struct{}, 1),
 		wg:          &sync.WaitGroup{},
-		log:         log.StandardLogger()}
+		log:         deathlog.DefaultLogger()}
 	signal.Notify(death.sigChannel, signals...)
 	death.wg.Add(1)
 	go death.listenForSignal()
@@ -61,7 +53,7 @@ func (d *Death) SetTimeout(t time.Duration) *Death {
 }
 
 // SetLogger Overrides the default logger (seelog)
-func (d *Death) SetLogger(l Logger) *Death {
+func (d *Death) SetLogger(l deathlog.Logger) *Death {
 	d.log = l
 	return d
 }

--- a/death.go
+++ b/death.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grindlemire/death/deathlog"
+	"github.com/vrecan/death/deathlog"
 )
 
 // Death manages the death of your application.

--- a/death_unix_test.go
+++ b/death_unix_test.go
@@ -26,21 +26,23 @@ func TestDeath(t *testing.T) {
 		u := make(Unhashable)
 		death := NewDeath(syscall.SIGTERM)
 		syscall.Kill(os.Getpid(), syscall.SIGTERM)
-		death.WaitForDeath(u)
+		err := death.WaitForDeath(u)
+		So(err, ShouldBeNil)
 	})
 
 	Convey("Validate death happens cleanly", t, func() {
 		death := NewDeath(syscall.SIGTERM)
 		syscall.Kill(os.Getpid(), syscall.SIGTERM)
-		death.WaitForDeath()
-
+		err := death.WaitForDeath()
+		So(err, ShouldBeNil)
 	})
 
 	Convey("Validate death happens with other signals", t, func() {
 		death := NewDeath(syscall.SIGHUP)
 		closeMe := &CloseMe{}
 		syscall.Kill(os.Getpid(), syscall.SIGHUP)
-		death.WaitForDeath(closeMe)
+		err := death.WaitForDeath(closeMe)
+		So(err, ShouldBeNil)
 		So(closeMe.Closed, ShouldEqual, 1)
 	})
 
@@ -48,7 +50,8 @@ func TestDeath(t *testing.T) {
 		death := NewDeath(syscall.SIGHUP)
 		closeMe := &CloseMe{}
 		death.FallOnSword()
-		death.WaitForDeath(closeMe)
+		err := death.WaitForDeath(closeMe)
+		So(err, ShouldBeNil)
 		So(closeMe.Closed, ShouldEqual, 1)
 	})
 
@@ -57,7 +60,8 @@ func TestDeath(t *testing.T) {
 		closeMe := &CloseMe{}
 		death.FallOnSword()
 		death.FallOnSword()
-		death.WaitForDeath(closeMe)
+		err := death.WaitForDeath(closeMe)
+		So(err, ShouldBeNil)
 		So(closeMe.Closed, ShouldEqual, 1)
 	})
 
@@ -66,7 +70,8 @@ func TestDeath(t *testing.T) {
 		closeMe := &CloseMe{}
 		death.FallOnSword()
 		death.FallOnSword()
-		death.WaitForDeath(closeMe)
+		err := death.WaitForDeath(closeMe)
+		So(err, ShouldBeNil)
 		death.FallOnSword()
 		death.FallOnSword()
 		So(closeMe.Closed, ShouldEqual, 1)
@@ -77,8 +82,8 @@ func TestDeath(t *testing.T) {
 		death.SetTimeout(10 * time.Millisecond)
 		neverClose := &neverClose{}
 		syscall.Kill(os.Getpid(), syscall.SIGHUP)
-		death.WaitForDeath(neverClose)
-
+		err := death.WaitForDeath(neverClose)
+		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Validate death uses new logger", t, func() {
@@ -88,7 +93,8 @@ func TestDeath(t *testing.T) {
 		death.SetLogger(logger)
 
 		syscall.Kill(os.Getpid(), syscall.SIGHUP)
-		death.WaitForDeath(closeMe)
+		err := death.WaitForDeath(closeMe)
+		So(err, ShouldBeNil)
 		So(closeMe.Closed, ShouldEqual, 1)
 		So(logger.Logs, ShouldNotBeEmpty)
 	})
@@ -99,7 +105,8 @@ func TestDeath(t *testing.T) {
 		neverClose := &neverClose{}
 		closeMe := &CloseMe{}
 		syscall.Kill(os.Getpid(), syscall.SIGHUP)
-		death.WaitForDeath(neverClose, closeMe)
+		err := death.WaitForDeath(neverClose, closeMe)
+		So(err, ShouldNotBeNil)
 		So(closeMe.Closed, ShouldEqual, 1)
 	})
 

--- a/deathlog/deathlog.go
+++ b/deathlog/deathlog.go
@@ -1,0 +1,23 @@
+package deathlog
+
+// Logger interface to log.
+type Logger interface {
+	Error(v ...interface{})
+	Debug(v ...interface{})
+	Info(v ...interface{})
+	Warn(v ...interface{})
+}
+
+type defaultLogger struct{}
+
+var logger = defaultLogger{}
+
+// DefaultLogger returns a logger that does nothing
+func DefaultLogger() Logger {
+	return logger
+}
+
+func (d defaultLogger) Error(v ...interface{}) {}
+func (d defaultLogger) Debug(v ...interface{}) {}
+func (d defaultLogger) Info(v ...interface{})  {}
+func (d defaultLogger) Warn(v ...interface{})  {}

--- a/deathlog/deathlog.go
+++ b/deathlog/deathlog.go
@@ -5,7 +5,6 @@ type Logger interface {
 	Error(v ...interface{})
 	Debug(v ...interface{})
 	Info(v ...interface{})
-	Warn(v ...interface{})
 }
 
 type defaultLogger struct{}
@@ -20,4 +19,3 @@ func DefaultLogger() Logger {
 func (d defaultLogger) Error(v ...interface{}) {}
 func (d defaultLogger) Debug(v ...interface{}) {}
 func (d defaultLogger) Info(v ...interface{})  {}
-func (d defaultLogger) Warn(v ...interface{})  {}

--- a/pkgPath_test.go
+++ b/pkgPath_test.go
@@ -1,9 +1,10 @@
 package death
 
 import (
+	"testing"
+
 	log "github.com/cihub/seelog"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func TestGetPkgPath(t *testing.T) {


### PR DESCRIPTION
When death hits the timeout for closing an object it should return an error so the caller knows we did not gracefully exit. 