### PR TITLE
Update go.mod to import v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vrecan/death
+module github.com/vrecan/death/v3
 
 go 1.14
 

--- a/pkgPath_test.go
+++ b/pkgPath_test.go
@@ -12,7 +12,7 @@ func TestGetPkgPath(t *testing.T) {
 		c := &Closer{}
 		name, pkgPath := getPkgPath(c)
 		So(name, ShouldEqual, "Closer")
-		So(pkgPath, ShouldEqual, "github.com/vrecan/death")
+		So(pkgPath, ShouldEqual, "github.com/vrecan/death/v3")
 
 	})
 
@@ -21,14 +21,14 @@ func TestGetPkgPath(t *testing.T) {
 		closable = Closer{}
 		name, pkgPath := getPkgPath(closable)
 		So(name, ShouldEqual, "Closer")
-		So(pkgPath, ShouldEqual, "github.com/vrecan/death")
+		So(pkgPath, ShouldEqual, "github.com/vrecan/death/v3")
 	})
 
 	Convey("Give pkgPath a copy", t, func() {
 		c := Closer{}
 		name, pkgPath := getPkgPath(c)
 		So(name, ShouldEqual, "Closer")
-		So(pkgPath, ShouldEqual, "github.com/vrecan/death")
+		So(pkgPath, ShouldEqual, "github.com/vrecan/death/v3")
 	})
 }
 


### PR DESCRIPTION
go module imports were failing for v3.0.2 because the `go.mod` file was not properly specifying a v3 at the end of the module name.

This fixes vrecan/death#44.